### PR TITLE
Work around Jetty Content-Length removal bug

### DIFF
--- a/src/test/java/com/bouncestorage/chaoshttpproxy/ChaosHttpProxyTest.java
+++ b/src/test/java/com/bouncestorage/chaoshttpproxy/ChaosHttpProxyTest.java
@@ -21,22 +21,30 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.EOFException;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HttpHeaders;
+import com.google.common.util.concurrent.Atomics;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.ProxyConfiguration;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.util.BytesContentProvider;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.Request;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
@@ -74,7 +82,17 @@ public final class ChaosHttpProxyTest {
                 proxyEndpoint.getQuery(), proxyEndpoint.getFragment());
         logger.debug("ChaosHttpProxy listening on {}", proxyEndpoint);
 
-        httpBin = new HttpBin(httpBinEndpoint);
+        setupHttpBin(new HttpBin(httpBinEndpoint));
+
+        client = new HttpClient();
+        ProxyConfiguration proxyConfig = client.getProxyConfiguration();
+        proxyConfig.getProxies().add(new HttpProxy(proxyEndpoint.getHost(),
+                proxyEndpoint.getPort()));
+        client.start();
+    }
+
+    private void setupHttpBin(final HttpBin httpBin) throws Exception {
+        this.httpBin = httpBin;
         httpBin.start();
 
         // reset endpoint to handle zero port
@@ -83,12 +101,6 @@ public final class ChaosHttpProxyTest {
                 httpBin.getPort(), httpBinEndpoint.getPath(),
                 httpBinEndpoint.getQuery(), httpBinEndpoint.getFragment());
         logger.debug("HttpBin listening on {}", httpBinEndpoint);
-
-        client = new HttpClient();
-        ProxyConfiguration proxyConfig = client.getProxyConfiguration();
-        proxyConfig.getProxies().add(new HttpProxy(proxyEndpoint.getHost(),
-                proxyEndpoint.getPort()));
-        client.start();
     }
 
     @After
@@ -204,6 +216,33 @@ public final class ChaosHttpProxyTest {
                 ImmutableList.of(Failure.HTTP_301, Failure.SUCCESS)));
         assertThat(client.GET(httpBinEndpoint + "/status/200").getStatus())
                 .as("status").isEqualTo(200);
+    }
+
+    @Test
+    public void testContentLengthNotStrippedByJettyBug() throws Exception {
+        // Set up a handler that asserts the presence of a content-length
+        httpBin.stop();
+        final AtomicReference<Boolean> gotContentLength =
+                Atomics.newReference(false);
+        setupHttpBin(new HttpBin(httpBinEndpoint, new HttpBinHandler() {
+                @Override
+                public void handle(String target, Request baseRequest,
+                        HttpServletRequest request,
+                        HttpServletResponse servletResponse)
+                        throws IOException {
+                    if (request.getHeader(
+                            HttpHeader.CONTENT_LENGTH.asString()) != null) {
+                        gotContentLength.set(true);
+                    }
+                }
+            }));
+
+        // The content has to be large-ish to exercise the bug
+        client.POST(httpBinEndpoint + "/post")
+                .content(new BytesContentProvider(new byte[65536]))
+                .header(HttpHeader.CONTENT_LENGTH, String.valueOf(65536))
+                .send();
+        assertThat(gotContentLength.get()).isTrue();
     }
 
     /** Supplier whose elements are provided by an Iterable. */

--- a/src/test/java/com/bouncestorage/chaoshttpproxy/HttpBin.java
+++ b/src/test/java/com/bouncestorage/chaoshttpproxy/HttpBin.java
@@ -32,9 +32,13 @@ final class HttpBin {
     private final Server server;
     private final HttpBinHandler handler;
 
-    public HttpBin(URI endpoint)
-            throws Exception {
+    public HttpBin(URI endpoint) throws Exception {
+        this(endpoint, new HttpBinHandler());
+    }
+
+    public HttpBin(URI endpoint, HttpBinHandler handler) throws Exception {
         requireNonNull(endpoint);
+        this.handler = handler;
 
         server = new Server();
         HttpConnectionFactory httpConnectionFactory =
@@ -44,7 +48,6 @@ final class HttpBin {
         connector.setHost(endpoint.getHost());
         connector.setPort(endpoint.getPort());
         server.addConnector(connector);
-        this.handler = new HttpBinHandler();
         server.setHandler(handler);
     }
 

--- a/src/test/java/com/bouncestorage/chaoshttpproxy/HttpBinHandler.java
+++ b/src/test/java/com/bouncestorage/chaoshttpproxy/HttpBinHandler.java
@@ -33,7 +33,7 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class HttpBinHandler extends AbstractHandler {
+class HttpBinHandler extends AbstractHandler {
     private static final Logger logger = LoggerFactory.getLogger(
             HttpBinHandler.class);
 


### PR DESCRIPTION
Trying to use chaos-http-proxy to test s3fs-fuse, I found that it's stripping out content-length headers. This turns out to be an apparent bug in Jetty (see referenced issue in the commit message).