### PR TITLE
Fail CONNECT methods

### DIFF
--- a/src/main/java/com/bouncestorage/chaoshttpproxy/ChaosHttpProxyHandler.java
+++ b/src/main/java/com/bouncestorage/chaoshttpproxy/ChaosHttpProxyHandler.java
@@ -69,6 +69,14 @@ final class ChaosHttpProxyHandler extends AbstractHandler {
     public void handle(String target, Request baseRequest,
             HttpServletRequest request, HttpServletResponse servletResponse)
             throws IOException {
+        // CONNECT is not supported pending implementation of MITM HTTPS
+        if (request.getMethod().equals("CONNECT")) {
+            logger.debug("CONNECT is not supported");
+            servletResponse.sendError(
+                    HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            return;
+        }
+
         Failure failure = supplier.get();
         logger.debug("request: {}", request);
         logger.debug("Failure: {}", failure);


### PR DESCRIPTION
Ideally there will be support for TLS-terminating HTTPS proxies
(see #1), but prior to that it's better to fail the CONNECT method w/
a 405 than to mis-compose the URL out of the request-uri component.