### PR TITLE
Extended configuration to allow json configuration via api

### DIFF
--- a/src/main/java/com/bouncestorage/chaoshttpproxy/ChaosApiHandler.java
+++ b/src/main/java/com/bouncestorage/chaoshttpproxy/ChaosApiHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 Bounce Storage, Inc. <info@bouncestorage.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bouncestorage.chaoshttpproxy;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+public class ChaosApiHandler extends AbstractHandler {
+
+    private ChaosHttpProxy chaosHttpProxy;
+    private ChaosHttpProxyHandler chaosHttpProxyHandler;
+
+    public ChaosApiHandler(ChaosHttpProxy chaosHttpProxy,
+            ChaosHttpProxyHandler chaosHttpProxyHandler) {
+        this.chaosHttpProxy = chaosHttpProxy;
+        this.chaosHttpProxyHandler = chaosHttpProxyHandler;
+    }
+
+    @Override
+    public final void handle(String target, Request baseRequest,
+            HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        if (target.equals("/chaos/api")) {
+            try (ServletOutputStream outputStream =
+                    response.getOutputStream()) {
+                if (request.getMethod().equals("POST")) {
+                    ChaosConfig chaosConfig =
+                            new DefaultChaosConfig(request.getInputStream());
+                    chaosHttpProxy.setChaosConfig(chaosConfig);
+                    chaosHttpProxyHandler
+                            .setFailureSupplier(new RandomFailureSupplier(
+                                    chaosConfig.getFailures()));
+
+                }
+                // we're assuming PUT and DELETE aren't used at all
+                // Code for GET will always execute, thus POST will always
+                // return equivalent values after processed.
+                response.setStatus(HttpServletResponse.SC_OK);
+                ChaosConfig chaosConfig = chaosHttpProxy.getChaosConfig();
+                chaosConfig.getProperties().store(outputStream,
+                        "Output via api");
+            } catch (Exception e) {
+                response.setStatus(
+                        HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            }
+
+        }
+
+    }
+}

--- a/src/main/java/com/bouncestorage/chaoshttpproxy/ChaosConfig.java
+++ b/src/main/java/com/bouncestorage/chaoshttpproxy/ChaosConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Bounce Storage, Inc. <info@bouncestorage.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bouncestorage.chaoshttpproxy;
+
+import java.util.List;
+import java.util.Properties;
+
+public interface ChaosConfig {
+
+    Properties getProperties();
+
+    List<Failure> getFailures();
+
+}

--- a/src/main/java/com/bouncestorage/chaoshttpproxy/ChaosHttpProxyHandler.java
+++ b/src/main/java/com/bouncestorage/chaoshttpproxy/ChaosHttpProxyHandler.java
@@ -56,8 +56,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 final class ChaosHttpProxyHandler extends AbstractHandler {
-    private static final Logger logger = LoggerFactory.getLogger(
-            ChaosHttpProxyHandler.class);
+    private static final Logger logger =
+            LoggerFactory.getLogger(ChaosHttpProxyHandler.class);
     private final HttpClient client;
     // TODO: AtomicReference?
     private Supplier<Failure> supplier;
@@ -75,8 +75,8 @@ final class ChaosHttpProxyHandler extends AbstractHandler {
         // CONNECT is not supported pending implementation of MITM HTTPS
         if (request.getMethod().equals("CONNECT")) {
             logger.debug("CONNECT is not supported");
-            servletResponse.sendError(
-                    HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            servletResponse
+                    .sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
             return;
         }
 
@@ -84,19 +84,19 @@ final class ChaosHttpProxyHandler extends AbstractHandler {
         logger.debug("request: {}", request);
         logger.debug("Failure: {}", failure);
         try (InputStream is = request.getInputStream();
-             OutputStream os = servletResponse.getOutputStream()) {
-            HostAndPort hostAndPort = HostAndPort.fromString(request.getHeader(
-                    HttpHeaders.HOST));
+                OutputStream os = servletResponse.getOutputStream()) {
+            HostAndPort hostAndPort =
+                    HostAndPort.fromString(request.getHeader(HttpHeaders.HOST));
             String queryString = request.getQueryString();
             URI uri;
             try {
-                uri = new URI(request.getScheme(),
-                        /*userInfo=*/ null,
-                        hostAndPort.getHostText(),
-                        hostAndPort.hasPort() ? hostAndPort.getPort() : 80,
-                        request.getRequestURI(),
-                        queryString,
-                        /*fragment=*/ null);
+                uri =
+                        new URI(request.getScheme(), /* userInfo= */ null,
+                                hostAndPort.getHostText(),
+                                hostAndPort.hasPort() ? hostAndPort.getPort() :
+                                    80,
+                                request.getRequestURI(), queryString,
+                                /* fragment= */ null);
             } catch (URISyntaxException use) {
                 throw new IOException(use);
             }
@@ -117,13 +117,13 @@ final class ChaosHttpProxyHandler extends AbstractHandler {
                 servletResponse.setStatus(failure.getResponseCode());
                 URI redirectUri;
                 try {
-                    redirectUri = new URI(request.getScheme(),
-                            /*userInfo=*/ null,
-                            hostAndPort.getHostText(),
-                            hostAndPort.hasPort() ? hostAndPort.getPort() : 80,
-                            "/" + UUID.randomUUID().toString(),
-                            /*query=*/ null,
-                            /*fragment=*/ null);
+                    redirectUri =
+                            new URI(request.getScheme(), /* userInfo= */ null,
+                                    hostAndPort.getHostText(),
+                                    hostAndPort.hasPort() ?
+                                            hostAndPort.getPort() : 80,
+                                    "/" + UUID.randomUUID().toString(),
+                                    /* query= */ null, /* fragment= */ null);
                 } catch (URISyntaxException use) {
                     throw new IOException(use);
                 }
@@ -148,14 +148,14 @@ final class ChaosHttpProxyHandler extends AbstractHandler {
             InputStreamResponseListener listener =
                     new InputStreamResponseListener();
             InputStream iss = failure == Failure.PARTIAL_REQUEST ?
-                    // TODO: random limit
+            // TODO: random limit
                     ByteStreams.limit(is, 1024) : is;
-            org.eclipse.jetty.client.api.Request clientRequest = client
-                    .newRequest(uri.toString())
-                    .method(request.getMethod());
+            org.eclipse.jetty.client.api.Request clientRequest =
+                    client.newRequest(uri.toString())
+                            .method(request.getMethod());
             long userContentLength = -1;
-            for (String headerName :
-                    Collections.list(request.getHeaderNames())) {
+            for (String headerName : Collections
+                    .list(request.getHeaderNames())) {
                 if (headerName.equalsIgnoreCase(HttpHeaders.EXPECT) ||
                         headerName.equalsIgnoreCase("Proxy-Connection")) {
                     continue;
@@ -177,11 +177,11 @@ final class ChaosHttpProxyHandler extends AbstractHandler {
             // https://bugs.eclipse.org/bugs/show_bug.cgi?id=475613.
             final long length = userContentLength;
             clientRequest.content(new InputStreamContentProvider(is) {
-                    @Override
-                    public long getLength() {
-                        return length != -1 ? length : super.getLength();
-                    }
-                });
+                @Override
+                public long getLength() {
+                    return length != -1 ? length : super.getLength();
+                }
+            });
             clientRequest.send(listener);
             if (failure == Failure.PARTIAL_REQUEST) {
                 return;
@@ -190,15 +190,16 @@ final class ChaosHttpProxyHandler extends AbstractHandler {
             Response response;
             try {
                 response = listener.get(Long.MAX_VALUE, TimeUnit.SECONDS);
-            } catch (ExecutionException | InterruptedException |
+            } catch (
+                    ExecutionException |
+                    InterruptedException |
                     TimeoutException e) {
                 throw new IOException(e);
             }
             int status = response.getStatus();
             logger.trace("status: {}", status);
             servletResponse.setStatus(status);
-            List<HttpField> headers = Lists.newArrayList(
-                    response.getHeaders());
+            List<HttpField> headers = Lists.newArrayList(response.getHeaders());
             if (failure == Failure.REORDER_HEADERS) {
                 Collections.shuffle(headers);
             }
@@ -213,8 +214,9 @@ final class ChaosHttpProxyHandler extends AbstractHandler {
                     break;
                 case CORRUPT_RESPONSE_CONTENT_MD5:
                     if (header.equals(HttpHeaders.CONTENT_MD5)) {
-                        value = BaseEncoding.base64().encode(
-                                new byte[Hashing.md5().bits() / 8]);
+                        value =
+                                BaseEncoding.base64().encode(
+                                        new byte[Hashing.md5().bits() / 8]);
                     }
                     break;
                 default:
@@ -256,5 +258,9 @@ final class ChaosHttpProxyHandler extends AbstractHandler {
     @VisibleForTesting
     void setFailureSupplier(Supplier<Failure> supplier) {
         this.supplier = requireNonNull(supplier);
+    }
+
+    Supplier<Failure> getFailureSupplier() {
+        return this.supplier;
     }
 }

--- a/src/main/java/com/bouncestorage/chaoshttpproxy/DefaultChaosConfig.java
+++ b/src/main/java/com/bouncestorage/chaoshttpproxy/DefaultChaosConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Bounce Storage, Inc. <info@bouncestorage.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bouncestorage.chaoshttpproxy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+public class DefaultChaosConfig implements ChaosConfig {
+
+    private List<Failure> failures;
+
+    private Properties properties;
+
+    public DefaultChaosConfig(InputStream is)
+            throws IOException {
+        properties = new Properties();
+        properties.load(is);
+        properties.putAll(System.getProperties());
+        failures = new ArrayList<>();
+        for (String propertyName : properties.stringPropertyNames()) {
+            if (!propertyName.startsWith(Failure.CHAOS_CONFIG_STRING)) {
+                properties.remove(propertyName);
+                continue;
+            }
+            Failure failure;
+            try {
+                failure = Failure.fromPropertyKey(propertyName);
+            } catch (IllegalArgumentException iae) {
+                System.err.println("Invalid failure: " + propertyName);
+                System.err.println("Valid failures:");
+                for (Failure failure2 : Failure.values()) {
+                    System.err.println(failure2.toString().toLowerCase());
+                }
+                System.exit(1);
+                throw iae;
+            }
+            int occurrences = Integer.parseInt(properties.getProperty(
+                    propertyName));
+            for (int i = 0; i < occurrences; ++i) {
+                failures.add(failure);
+            }
+        }
+
+    }
+
+    /* (non-Javadoc)
+     * @see com.bouncestorage.chaoshttpproxy.ChaosConfig_#getFailures()
+     */
+    @Override
+    public final List<Failure> getFailures() {
+        return failures;
+    }
+
+    /* (non-Javadoc)
+     * @see com.bouncestorage.chaoshttpproxy.ChaosConfig_#getProperties()
+     */
+    @Override
+    public final Properties getProperties() {
+        return properties;
+    }
+
+
+}

--- a/src/main/java/com/bouncestorage/chaoshttpproxy/Failure.java
+++ b/src/main/java/com/bouncestorage/chaoshttpproxy/Failure.java
@@ -56,6 +56,9 @@ enum Failure {
     /** Default. */
     SUCCESS;
 
+    public static final String CHAOS_CONFIG_STRING =
+            "com.bouncestorage.chaoshttpproxy.";
+
     private int responseCode;
 
     Failure() {
@@ -69,4 +72,14 @@ enum Failure {
     int getResponseCode() {
         return responseCode;
     }
+
+    public String toString() {
+        return Failure.CHAOS_CONFIG_STRING + super.toString();
+    }
+
+    public static Failure fromPropertyKey(String propertyKey) {
+        return Failure.valueOf(propertyKey
+                .substring(Failure.CHAOS_CONFIG_STRING.length()).toUpperCase());
+    }
+
 }

--- a/src/main/java/com/bouncestorage/chaoshttpproxy/RandomFailureSupplier.java
+++ b/src/main/java/com/bouncestorage/chaoshttpproxy/RandomFailureSupplier.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Bounce Storage, Inc. <info@bouncestorage.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bouncestorage.chaoshttpproxy;
+
+import java.util.List;
+import java.util.Random;
+
+import com.google.common.base.Supplier;
+
+public class RandomFailureSupplier implements Supplier<Failure> {
+
+    private final Random random = new Random();
+    private final List<Failure> failures;
+
+    public RandomFailureSupplier(List<Failure> failures) {
+        this.failures = failures;
+    }
+
+    public final List<Failure> getFailures() {
+        return failures;
+    }
+
+    @Override
+    public final Failure get() {
+        return failures.get(random.nextInt(failures.size()));
+    }
+}

--- a/src/test/java/com/bouncestorage/chaoshttpproxy/DefaultChaosConfigTest.java
+++ b/src/test/java/com/bouncestorage/chaoshttpproxy/DefaultChaosConfigTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015 Bounce Storage, Inc. <info@bouncestorage.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bouncestorage.chaoshttpproxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.Properties;
+
+import org.junit.Test;
+
+public class DefaultChaosConfigTest {
+
+    @Test
+    public final void testPropertyFromStream() throws Exception {
+        final PipedOutputStream os = new PipedOutputStream();
+        PipedInputStream is = new PipedInputStream(os);
+        final Properties properties = new Properties();
+        properties.put(Failure.HTTP_301.toString(), "2");
+        properties.put(Failure.SUCCESS.toString(), "3");
+        properties.put("random_key", "random_value");
+        new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    properties.store(os, "no comment");
+                    os.close();
+                } catch (IOException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+
+            }
+        }).start();
+        DefaultChaosConfig config = new DefaultChaosConfig(is);
+
+        Properties configProperties = config.getProperties();
+
+        assertFailureMatch(properties, Failure.HTTP_301, configProperties);
+
+        assertFailureMatch(properties, Failure.SUCCESS, configProperties);
+
+        assertThat(configProperties.containsKey("random_key")).as("extra keys")
+                .isEqualTo(false);
+
+    }
+
+    private void assertFailureMatch(final Properties properties,
+            Failure failure, Properties configProperties) {
+        assertThat(configProperties.containsKey(failure.toString()))
+                .as("has key" + failure.toString()).isEqualTo(true);
+        assertThat(configProperties.get(failure.toString()))
+                .as("has value" + failure.toString())
+                .isEqualTo(properties.getProperty(failure.toString()));
+    }
+
+}


### PR DESCRIPTION
Changed jetty handler to HandlerList and added a second handler to parse
json configuration messages.

POST
{
"http_301":1,
"http_302":1,
"http_303":1,
"http_307":1,
"http_308":1,
"http_408":1,
"http_500":1,
"http_503":1,
"http_504":1,
"change_header_case":1,
"corrupt_request_content_md5":1,
"corrupt_response_content_md5":1,
"partial_data":1,
"reorder_headers":1,
"slow_response":1,
"timeout":1,
"success":83
}